### PR TITLE
Fixes application name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #   include authy
 class authy {
-  package { 'Authy':
+  package { 'Authy Bluetooth':
     provider => 'compressed_app',
     source   => 'https://www.authy.com/authy-desktop/Authy_Bluetooth-1.3.app.zip',
   }


### PR DESCRIPTION
The app name seems to be wrong, it's `/Applications/Authy Bluetooth.app` and chown is failing due to this.
